### PR TITLE
Fix link to license

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,9 @@ forget to change your picture!
 ## License
 
 All content in this repository is licensed under the
-[Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+[Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/).
 You are free to share and adapt the content, but you must give appropriate
 credit, provide a link to the license, and indicate if changes were made.
-You may not use the material for commercial purposes. See [LICENSE](./LICENSE)
-for the full license text.
+See [LICENSE](./LICENSE) for the full license text.
 
 For any other use, please contact the author for permission.


### PR DESCRIPTION
Naam van licentie in de tekst komt niet overeen met originele ./LICENSE